### PR TITLE
Feature/compile command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
 name = "bstr"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +60,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "difflib"
@@ -66,6 +84,22 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "errno"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "float-cmp"
@@ -90,6 +124,12 @@ name = "libc"
 version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "memchr"
@@ -162,6 +202,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +238,19 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "rustix"
+version = "0.38.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
+dependencies = [
+ "bitflags 2.4.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "serde"
@@ -222,6 +284,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,9 +318,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
 name = "zk_whitelist"
 version = "1.1.0"
 dependencies = [
  "assert_cmd",
  "predicates",
+ "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2021"
 [dev-dependencies]
 assert_cmd = "2.0.12"
 predicates = "3.0.4"
+tempfile = "3.8.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::fs::File;
 use std::io::{self, Write};
 use std::path::Path;
+use std::process::Command;
 
 fn main() -> io::Result<()> {
     let args: Vec<String> = env::args().collect();
@@ -9,6 +10,8 @@ fn main() -> io::Result<()> {
         display_version();
     } else if args.contains(&"circuit".to_string()) {
         copy_circuit_file()?;
+    } else if args.contains(&"compile".to_string()) {
+        compile_circuit()?;
     }
 
     Ok(())
@@ -26,5 +29,25 @@ fn copy_circuit_file() -> io::Result<()> {
     let circuit_path = Path::new(&current_dir).join("circuit.circom");
     let mut file = File::create(circuit_path)?;
     file.write_all(include_bytes!("../templates/circuit.circom"))?;
+    Ok(())
+}
+
+fn compile_circuit() -> io::Result<()> {
+    let current_dir = env::current_dir()?;
+    eprintln!("Working directory: {:?}", current_dir);
+    let output = Command::new("circom")
+        .current_dir(&current_dir)
+        .arg("circuit.circom")
+        .args(&["--r1cs", "--sym", "--wasm"])
+        .output()?;
+    
+    eprintln!("circom stdout: {}", String::from_utf8_lossy(&output.stdout));
+    eprintln!("circom stderr: {}", String::from_utf8_lossy(&output.stderr));
+
+    
+    if !output.status.success() {
+        return Err(io::Error::new(io::ErrorKind::Other, "Compilation failed"));
+    }
+    
     Ok(())
 }

--- a/templates/circuit.circom
+++ b/templates/circuit.circom
@@ -7,4 +7,4 @@ template Whitelist() {
     assert(a==b);
 }
 
-component main {public b} = Whitelist();
+component main {public [b]} = Whitelist();

--- a/templates/circuit.circom
+++ b/templates/circuit.circom
@@ -1,10 +1,10 @@
 pragma circom 2.1.6;
 
 template Whitelist() {
-    signal input a;
-    signal input b;
+    signal input addressInDecimal;
+    signal input sameAddressButPublic;
     
-    assert(a==b);
+    assert(addressInDecimal==sameAddressButPublic);
 }
 
-component main {public [b]} = Whitelist();
+component main {public [sameAddressButPublic]} = Whitelist();

--- a/tests/circuit_command_tests.rs
+++ b/tests/circuit_command_tests.rs
@@ -2,27 +2,36 @@
 mod tests {
     use assert_cmd::Command;
     use std::fs;
-    use std::path::Path;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
 
     #[test]
     fn test_circuit_command() {
         // Arrange
-        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-        let current_dir = std::env::current_dir().unwrap();
-        let circuit_path = Path::new(&current_dir).join("circuit.circom");
+        let temp_dir = tempdir().unwrap();
+        let current_dir = temp_dir.path().to_path_buf();
         let expected_content = include_bytes!("../templates/circuit.circom");
 
         // Act
-        cmd.arg("circuit")
-            .assert()
-            .success();
-        let actual_content = fs::read(circuit_path.clone()).unwrap();
+        let circuit_path = execute_circuit_command(&current_dir);
+        let actual_content = fs::read(&circuit_path).unwrap();
 
         // Assert
-        assert!(circuit_path.exists());
-        assert_eq!(expected_content, actual_content.as_slice());
+        assert_files_match(expected_content, &actual_content, &circuit_path);
 
-        // Clean up: Remove the created circuit.circom file
-        fs::remove_file(circuit_path).expect("Failed to remove circuit.circom");
+    }
+
+    fn execute_circuit_command(dir: &PathBuf) -> PathBuf {
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        cmd.current_dir(dir)
+            .arg("circuit")
+            .assert()
+            .success();
+        dir.join("circuit.circom")
+    }
+
+    fn assert_files_match(expected_content: &[u8], actual_content: &[u8], file_path: &PathBuf) {
+        assert!(file_path.exists());
+        assert_eq!(expected_content, actual_content);
     }
 }

--- a/tests/compile_command_tests.rs
+++ b/tests/compile_command_tests.rs
@@ -1,0 +1,43 @@
+#[cfg(test)]
+mod tests {
+    use assert_cmd::Command;
+    use std::fs;
+    use std::path::Path;
+
+    #[test]
+    fn test_compile_command() {
+        // Arrange
+        let current_dir = std::env::current_dir().unwrap();
+        let r1cs_path = Path::new(&current_dir).join("circuit.r1cs");
+        let sym_path = Path::new(&current_dir).join("circuit.sym");
+        let wasm_dir_path = Path::new(&current_dir).join("circuit_js");
+        let wasm_path = Path::new(&current_dir).join("circuit_js/circuit.wasm");
+
+        // Act: Execute the circuit command to create circuit.circom
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        cmd.arg("circuit")
+            .assert()
+            .success();
+
+        // Reset the command object
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+
+        // Act: Execute the compile command
+        cmd.arg("compile")
+            .assert()
+            .success();
+
+        // Assert
+        assert!(r1cs_path.exists());
+        assert!(sym_path.exists());
+        assert!(wasm_path.exists());
+        assert!(wasm_dir_path.exists());
+
+        // Clean up: Remove the created files
+        fs::remove_file(Path::new(&current_dir).join("circuit.circom")).expect("Failed to remove circuit.circom");
+        fs::remove_file(r1cs_path).expect("Failed to remove circuit.r1cs");
+        fs::remove_file(sym_path).expect("Failed to remove circuit.sym");
+        fs::remove_file(wasm_path).expect("Failed to remove circuit.wasm");
+        fs::remove_dir_all(wasm_dir_path).expect("Failed to remove circuit_js directory");
+    }
+}

--- a/tests/compile_command_tests.rs
+++ b/tests/compile_command_tests.rs
@@ -1,43 +1,46 @@
 #[cfg(test)]
 mod tests {
     use assert_cmd::Command;
+    use std::error::Error;
     use std::fs;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
+    use tempfile::tempdir;
 
     #[test]
     fn test_compile_command() {
         // Arrange
-        let current_dir = std::env::current_dir().unwrap();
-        let r1cs_path = Path::new(&current_dir).join("circuit.r1cs");
-        let sym_path = Path::new(&current_dir).join("circuit.sym");
-        let wasm_dir_path = Path::new(&current_dir).join("circuit_js");
-        let wasm_path = Path::new(&current_dir).join("circuit_js/circuit.wasm");
+        let temp_dir = tempdir().unwrap();
+        let current_dir = temp_dir.path().to_path_buf();
+        create_circuit_file(&current_dir).unwrap();
 
-        // Act: Execute the circuit command to create circuit.circom
-        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-        cmd.arg("circuit")
-            .assert()
-            .success();
-
-        // Reset the command object
-        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-
-        // Act: Execute the compile command
-        cmd.arg("compile")
-            .assert()
-            .success();
+        // Act
+        execute_compile_command(&current_dir);
 
         // Assert
+        assert_compiled_files_exist(&current_dir);
+
+    }
+
+    fn create_circuit_file(dir: &Path) -> Result<PathBuf, Box<dyn Error>> {
+        let circuit_path = dir.join("circuit.circom");
+        fs::write(&circuit_path, include_bytes!("../templates/circuit.circom"))?;
+        Ok(circuit_path)
+    }
+
+    fn execute_compile_command(dir: &Path) {
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        cmd.current_dir(dir)
+            .arg("compile")
+            .assert()
+            .success();
+    }
+
+    fn assert_compiled_files_exist(dir: &Path) {
+        let r1cs_path = dir.join("circuit.r1cs");
+        let sym_path = dir.join("circuit.sym");
+        let wasm_dir_path = dir.join("circuit_js");
         assert!(r1cs_path.exists());
         assert!(sym_path.exists());
-        assert!(wasm_path.exists());
         assert!(wasm_dir_path.exists());
-
-        // Clean up: Remove the created files
-        fs::remove_file(Path::new(&current_dir).join("circuit.circom")).expect("Failed to remove circuit.circom");
-        fs::remove_file(r1cs_path).expect("Failed to remove circuit.r1cs");
-        fs::remove_file(sym_path).expect("Failed to remove circuit.sym");
-        fs::remove_file(wasm_path).expect("Failed to remove circuit.wasm");
-        fs::remove_dir_all(wasm_dir_path).expect("Failed to remove circuit_js directory");
     }
 }


### PR DESCRIPTION
### Summary
Implemented the `compile` command to execute the `circom` compilation process for the generated `circuit.circom` file. This PR includes tests, command implementation, and refactoring for better code organization and readability.

### Changes
- Added tests for `compile` command.
- Implemented `compile` command.
- Refactored `circuit` command for improved readability.
- Other minor refactoring in test files.