### PR TITLE
refactor(cli): :recycle: Remove tempfile usage for better CI compatib…

### DIFF
--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -10,13 +10,38 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  test:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 20
+
+      - name: Clone and Install Circom
+        run: |
+          git clone https://github.com/iden3/circom.git
+          cd circom
+          cargo install --path .
+
+      - name: Install SnarkJS
+        run: |
+          npm install -g snarkjs
+
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Build Project
+        run: |
+          cargo build
+
+      - name: Run Tests
+        run: |
+          cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,18 +39,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
-
-[[package]]
 name = "bstr"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,12 +48,6 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "difflib"
@@ -84,22 +66,6 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
-
-[[package]]
-name = "errno"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "float-cmp"
@@ -124,12 +90,6 @@ name = "libc"
 version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "memchr"
@@ -202,15 +162,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "regex"
 version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,19 +189,6 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
-
-[[package]]
-name = "rustix"
-version = "0.38.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
-dependencies = [
- "bitflags 2.4.1",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
 
 [[package]]
 name = "serde"
@@ -284,19 +222,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
-dependencies = [
- "cfg-if",
- "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,76 +243,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
 name = "zk_whitelist"
 version = "1.1.0"
 dependencies = [
  "assert_cmd",
  "predicates",
- "tempfile",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,3 @@ edition = "2021"
 [dev-dependencies]
 assert_cmd = "2.0.12"
 predicates = "3.0.4"
-tempfile = "3.8.1"

--- a/tests/circuit_command_tests.rs
+++ b/tests/circuit_command_tests.rs
@@ -2,35 +2,34 @@
 mod tests {
     use assert_cmd::Command;
     use std::fs;
-    use std::path::PathBuf;
-    use tempfile::tempdir;
+    use std::path::Path;
 
     #[test]
     fn test_circuit_command() {
         // Arrange
-        let temp_dir = tempdir().unwrap();
-        let current_dir = temp_dir.path().to_path_buf();
+        let current_dir = std::env::current_dir().unwrap();
+        let circuit_path = current_dir.join("circuit.circom");
         let expected_content = include_bytes!("../templates/circuit.circom");
 
         // Act
-        let circuit_path = execute_circuit_command(&current_dir);
-        let actual_content = fs::read(&circuit_path).unwrap();
+        execute_circuit_command();
 
         // Assert
+        let actual_content = fs::read(&circuit_path).unwrap();
         assert_files_match(expected_content, &actual_content, &circuit_path);
 
+        // Clean up: Remove the created circuit.circom file
+        fs::remove_file(circuit_path).unwrap();
     }
 
-    fn execute_circuit_command(dir: &PathBuf) -> PathBuf {
+    fn execute_circuit_command() {
         let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-        cmd.current_dir(dir)
-            .arg("circuit")
+        cmd.arg("circuit")
             .assert()
             .success();
-        dir.join("circuit.circom")
     }
 
-    fn assert_files_match(expected_content: &[u8], actual_content: &[u8], file_path: &PathBuf) {
+    fn assert_files_match(expected_content: &[u8], actual_content: &[u8], file_path: &Path) {
         assert!(file_path.exists());
         assert_eq!(expected_content, actual_content);
     }

--- a/tests/compile_command_tests.rs
+++ b/tests/compile_command_tests.rs
@@ -1,17 +1,14 @@
 #[cfg(test)]
 mod tests {
     use assert_cmd::Command;
-    use std::error::Error;
     use std::fs;
-    use std::path::{Path, PathBuf};
-    use tempfile::tempdir;
+    use std::path::Path;
 
     #[test]
     fn test_compile_command() {
         // Arrange
-        let temp_dir = tempdir().unwrap();
-        let current_dir = temp_dir.path().to_path_buf();
-        create_circuit_file(&current_dir).unwrap();
+        let current_dir = std::env::current_dir().unwrap();
+        create_circuit_file(&current_dir);
 
         // Act
         execute_compile_command(&current_dir);
@@ -19,12 +16,13 @@ mod tests {
         // Assert
         assert_compiled_files_exist(&current_dir);
 
+        // Clean up
+        clean_up_files(&current_dir);
     }
 
-    fn create_circuit_file(dir: &Path) -> Result<PathBuf, Box<dyn Error>> {
+    fn create_circuit_file(dir: &Path) {
         let circuit_path = dir.join("circuit.circom");
-        fs::write(&circuit_path, include_bytes!("../templates/circuit.circom"))?;
-        Ok(circuit_path)
+        fs::write(&circuit_path, include_bytes!("../templates/circuit.circom")).unwrap();
     }
 
     fn execute_compile_command(dir: &Path) {
@@ -42,5 +40,12 @@ mod tests {
         assert!(r1cs_path.exists());
         assert!(sym_path.exists());
         assert!(wasm_dir_path.exists());
+    }
+
+    fn clean_up_files(dir: &Path) {
+        fs::remove_file(dir.join("circuit.circom")).unwrap();
+        fs::remove_file(dir.join("circuit.r1cs")).unwrap();
+        fs::remove_file(dir.join("circuit.sym")).unwrap();
+        fs::remove_dir_all(dir.join("circuit_js")).unwrap();
     }
 }


### PR DESCRIPTION
### Summary
Refactored the test files to remove the usage of the `tempfile` crate, addressing the failure in GitHub Actions. The tests now utilize the current working directory for file operations, ensuring better compatibility with CI environments.

### Changes
- Removed `tempfile` usage in `compile_command_tests.rs` and `circuit_command_tests.rs`.
- Removed `tempfile` dependency from `Cargo.toml` and `Cargo.lock`
- Utilized the current working directory for file operations in tests.
- Added cleanup functions to remove any files and directories created during tests.

### Check
- [x] Tests pass in the CI environment.
- [x] No leftover files after tests are executed.
