### PR TITLE
Migrate CLI Argument Parsing to Clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
 
 [[package]]
 name = "assert_cmd"
@@ -50,6 +92,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac495e00dcec98c83465d5ad66c5c4fabd652fd6686e7c6269b117e729a6f17b"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77ed9a32a62e6ca27175d00d29d05ca32e396ea1eb5fb01d8256b669cec7663"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,6 +163,12 @@ checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "itertools"
@@ -211,6 +305,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +334,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,9 +349,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
 name = "zk_whitelist"
 version = "1.2.1"
 dependencies = [
  "assert_cmd",
+ "clap",
  "predicates",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version= "4.4.7", features = ["derive"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.12"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,29 +1,49 @@
+use clap::{Parser, Subcommand};
 use std::env;
 use std::fs::File;
 use std::io::{self, Write};
 use std::path::Path;
 use std::process::Command;
 
+/// Represents the command line interface for the Zero Knowledge Whitelist Tool.
+/// Deriving `Parser` from clap allows for automatic parsing of command line arguments.
+#[derive(Parser)]
+#[clap(
+    name = "Zero Knowledge Whitelist Tool",
+    version = env!("CARGO_PKG_VERSION"),
+    author = "Nikos Koumbakis <n.koumbakis@gmail.com>",
+    about = "This tool orchestrates the management of an address whitelist using Zero-Knowledge (ZK) proofs.\nSimply input the addresses, and it will generate the corresponding Solidity code.\nIt streamlines the process of maintaining a secure and efficient whitelist for your decentralized application."
+)]
+struct Cli {
+    /// The subcommand to be executed, parsed from the command line arguments.
+    #[clap(subcommand)]
+    subcmd: SubCommand,
+}
+
+/// Enumerates the available subcommands.
+/// Deriving `Subcommand` from clap provides automatic subcommand handling.
+#[derive(Subcommand)]
+enum SubCommand {
+    /// The `circuit` subcommand copies a circuit file template to the current directory.
+    Circuit,
+    /// The `compile` subcommand compiles the circuit file.
+    Compile,
+}
+/// The entry point of the application.
+/// Parses command line arguments and executes the corresponding subcommand.
 fn main() -> io::Result<()> {
-    let args: Vec<String> = env::args().collect();
-    if args.contains(&"--version".to_string()) || args.contains(&"--v".to_string()) {
-        display_version();
-    } else if args.contains(&"circuit".to_string()) {
-        copy_circuit_file()?;
-    } else if args.contains(&"compile".to_string()) {
-        compile_circuit()?;
+    let args = Cli::parse();
+
+    match args.subcmd {
+        SubCommand::Circuit => copy_circuit_file()?,
+        SubCommand::Compile => compile_circuit()?,
     }
 
     Ok(())
 }
 
-fn display_version() {
-    println!(
-        "Zero Knowledge Whitelist Tool, version {}",
-        env!("CARGO_PKG_VERSION")
-    );
-}
-
+/// Copies a circuit file template to the current directory.
+/// This function is called when the `circuit` subcommand is used.
 fn copy_circuit_file() -> io::Result<()> {
     let current_dir = env::current_dir()?;
     let circuit_path = Path::new(&current_dir).join("circuit.circom");
@@ -32,6 +52,8 @@ fn copy_circuit_file() -> io::Result<()> {
     Ok(())
 }
 
+/// Compiles the circuit file using the circom compiler.
+/// This function is called when the `compile` subcommand is used.
 fn compile_circuit() -> io::Result<()> {
     let current_dir = env::current_dir()?;
     eprintln!("Working directory: {:?}", current_dir);
@@ -40,14 +62,13 @@ fn compile_circuit() -> io::Result<()> {
         .arg("circuit.circom")
         .args(&["--r1cs", "--sym", "--wasm"])
         .output()?;
-    
+
     eprintln!("circom stdout: {}", String::from_utf8_lossy(&output.stdout));
     eprintln!("circom stderr: {}", String::from_utf8_lossy(&output.stderr));
 
-    
     if !output.status.success() {
         return Err(io::Error::new(io::ErrorKind::Other, "Compilation failed"));
     }
-    
+
     Ok(())
 }

--- a/tests/circuit_command_tests.rs
+++ b/tests/circuit_command_tests.rs
@@ -24,9 +24,7 @@ mod tests {
 
     fn execute_circuit_command() {
         let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-        cmd.arg("circuit")
-            .assert()
-            .success();
+        cmd.arg("circuit").assert().success();
     }
 
     fn assert_files_match(expected_content: &[u8], actual_content: &[u8], file_path: &Path) {

--- a/tests/clap_general_commands_test.rs
+++ b/tests/clap_general_commands_test.rs
@@ -1,0 +1,40 @@
+/// Module for CLI-related tests.
+///
+/// This module contains tests that verify the behavior of the command-line
+/// interface, including argument parsing and error handling.
+#[cfg(test)]
+mod tests {
+    use assert_cmd::Command;
+    use predicates::str::contains;
+
+    /// Tests the output of the `--help` flag.
+    ///
+    /// This test verifies that the `--help` flag produces the expected output,
+    /// including a portion of the about message and the names of the available
+    /// subcommands.
+    #[test]
+    fn test_help_flag() {
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        cmd.arg("--help")
+            .assert()
+            .success()
+            .stdout(contains(
+                "orchestrates the management of an address whitelist",
+            ))
+            .stdout(contains("circuit"))
+            .stdout(contains("compile"));
+    }
+
+    /// Tests the error message for an unrecognized subcommand.
+    ///
+    /// This test verifies that using an unrecognized subcommand results in an
+    /// error message indicating that the subcommand is not recognized.
+    #[test]
+    fn test_unrecognized_subcommand() {
+        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+        cmd.arg("unrecognized")
+            .assert()
+            .failure()
+            .stderr(contains("error: unrecognized subcommand 'unrecognized'"));
+    }
+}

--- a/tests/compile_command_tests.rs
+++ b/tests/compile_command_tests.rs
@@ -27,10 +27,7 @@ mod tests {
 
     fn execute_compile_command(dir: &Path) {
         let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
-        cmd.current_dir(dir)
-            .arg("compile")
-            .assert()
-            .success();
+        cmd.current_dir(dir).arg("compile").assert().success();
     }
 
     fn assert_compiled_files_exist(dir: &Path) {


### PR DESCRIPTION
This Pull Request introduces a migration of the CLI argument parsing to use the Clap library. The motivation behind this migration is to enhance the CLI's usability and maintainability, providing a structured and extensible approach to handling command-line arguments and subcommands.

Key Changes:

- Implemented a Cli struct and a SubCommand enum to represent the available command-line arguments and subcommands in a structured manner.
- Updated the main function to use Clap for parsing command-line arguments and dispatching subcommands.
- Replaced manual argument parsing with Clap's automatic parsing, streamlining the argument handling process.
- Improved error messages and help output by leveraging Clap's built-in functionalities.

Benefits:

- **Usability**: Users now have access to more informative help messages and a clearer command-line interface.
- **Maintainability**: The new structured approach makes the code easier to read, understand, and extend with new features in the future.
- **Error Handling**: Better error handling with clear error messages when incorrect arguments or subcommands are used.

This migration alters the way command-line arguments are parsed and handled, marking a significant improvement in the CLI's usability and code maintainability. Users now have access to more informative help messages and a clearer command-line interface.
